### PR TITLE
Added missing sections of the tech-list

### DIFF
--- a/source/content/tech-list/enemies.md
+++ b/source/content/tech-list/enemies.md
@@ -1,0 +1,50 @@
++++
+title = "Enemies and Enemy Drops"
+weight = 15
++++
+
+## Any Enemy
+
+### Kill Jump
+When destroying an enemy by landing on it, hold the jump button. GR-18 will ascend **4** tiles above the top of the enemy.
+
+### Boosted Kill Jump _(AKA Kill Launch)_
+When destroying an enemy by landing on it, press the jump button immediately **after** destroying the enemy.GR-18 will ascend **5** tiles above the top of the enemy.
+
+### Momentum Cancel Kill Jump _(AKA Fizzled Kill Jump)_
+If you stop pressing the jump button the moment you kill the enemy. You will only slightly bounce off of it.
+
+## Blopfush
+
+### Flying Waylay
+
+See[Flying Waylay]({{< relref "all-powered-up.md#flying-waylay-aka-discount-ripcord" >}})
+
+## Flapjack
+
+### Flapsack Super Jump
+Throw a flapsack, jump, and then jump again when on top of the flapsack. This allows GR-18 to reach up to **10 tiles** high. This is a similar technique to a Super Jump. It can be performed with similar alterations such as diagonally and off a wall.
+
+Tech demo video :[Flaspsack Jumps - aradarbel10](https://streamable.com/p5pd28)
+
+### Flapsack Bounce Jump
+While mid-air, throw the flapsack downwards. The flapsack will bounce off the ground allowing GR-18 to perform a Flapsack Super Jump. This can be useful for traversing surfaces that would kill GR-18 and bounce a flapsack.
+
+Tech demo video :[Flaspsack Jumps - aradarbel10](https://streamable.com/p5pd28)
+
+## Ocula & Scrubb
+
+### Squash Super Jump
+Throw a Squished Scrubb upwards, then jump around and on top of it. Jump again. This allows GR-18 to reach a height of **10 tiles** . This technique is similar to a Super Jump, except the Squished Scrubb cannot be jumped up and through.
+
+### Squash Wall Jump
+Start 1 to 2 tiles away from a wall. When approaching the peak of the jump, throw the Squished Scrubb against the wall. It will bounce back to GR-18, which can then be jumped off of. This technique can reach **10 tiles** . For an easy execution that can only reach 9 tiles, do not let go of the initial jump.
+
+Tech demo video :[Scubb Wall Jump - Sleepy Doof](https://cdn.discordapp.com/attachments/586641629948149761/700264046351613971/t6P5q7aajt.webm)
+
+## Popjaw
+
+### Popjump _(AKA Popjaw Pop)_
+GR-18 usually ‘pops’ up 1 tile after a medallion teleport. This can be increased to a height of 5 by pressing jump just as the teleportation activates.
+
+Tech demo video :[Levelhead Popjaw Pop Example - TripleB36](https://www.youtube.com/watch?v=qyjNo4_8wQE)

--- a/source/content/tech-list/environment.md
+++ b/source/content/tech-list/environment.md
@@ -1,0 +1,89 @@
++++
+title = "The Environment"
+weight = 15
++++
+Tech for things that GR-18 can’t take along for the adventure.
+
+## Blaster
+
+### Blasted Zipper Shift
+
+[See entry under Zipper]({{< relref "all-powered-up.md#blasted-zipper-shift" >}})
+
+## BUDD-E
+
+### Respawn Invuln
+Respawn at a BUDD-E. GR-18 receives a few frames of invulnerability. GR-18 can bypass non-solid hazards during these frames.
+
+## Bumper
+
+### Bump Jump _(AKA Bumper Jump)_
+From a solid surface, walk onto a bumper flush with the surface and press jump on contact with the bumper. GR-18 will be propelled **12** tiles upwards.
+While sprinting on a solid surface, jump as you hit a bumper that is flush with the surface. GR-18 will launch about **15** tiles upwards.
+
+Tech demo level :[d0q9w69 | "Bumper Jump Lesson" by BscotchKarl @bscotch042](https://levelhead.io/+d0q9w69)
+Tech demo level :[cjx34x4 | "Bumper: Big Jump!" by SleepyDoof @zchv6z](https://levelhead.io/+cjx34x4)
+Tech demo level :[bp7gn0r | "Bump Jump Tutorial" by Tim Conceivable @rmk4os](https://levelhead.io/+bp7gn0r)
+
+## Flingo
+
+### Flingo-go
+Grab a flingo parallel with the ground. GR-18 will immediately gain sprint speed..
+
+## Flyblock
+
+### Flyjump
+Jump from a moving flyblock or any moving standable surface to jump further and higher.
+
+Tech demo level :[0m4xh00 | "Moment Uh Jump Lesson" by BscotchKarl @bscotch042](https://levelhead.io/+0m4xh00)
+
+### Flyboost
+
+[See Up-Boosted Package Jump]({{< relref "you-and-the-goods.md#up-boosted-package-jump" >}})
+
+## Sky Wiggler
+
+### Wiggle Walk
+Hold down while on a wiggler to descend down the wiggler. Once stable on the wiggler, hold down-right or down-left to walk along the wiggler.
+
+### Basic Wiggler Launch
+Hold down on a sky wiggler until GR-18’s feet are touching the wiggler, then release. The wiggler will launch GR-18 **8** tiles upwards.
+
+Tech demo level :[1ptzc9k | "No Down Sky Wiggler Jump" by PureKnickers @ref0kg](https://lvlhd.co/+1ptzc9k)
+
+### Wiggler Jump Launch
+Hold down on a sky wiggler until GR-18’s feet are touching the wiggler and then press jump to launch GR-18 **14** tiles upwards.
+
+Tech demo level :[1ptzc9k | "No Down Sky Wiggler Jump" by PureKnickers @ref0kg](https://lvlhd.co/+1ptzc9k)
+
+### Wiggler Toe Touch Launch
+Hold down on a sky wiggler until GR-18’s feet **almost** touchthe wiggler, let go of all directions while pressing jump to launch GR-18 **17** tiles upwards. The technique was successful if the jump sound and animation do not play.
+
+Tech demo level :[1ptzc9k | "No Down Sky Wiggler Jump" by PureKnickers @ref0kg](https://lvlhd.co/+1ptzc9k)
+
+### Stable Drift
+Without vertical momentum, enter a series of wigglers about 4 tiles above the wigglers to traverse the wigglers with minimal vertical movement. Entering at the peak of GR-18’s normal jump works for this tech.
+
+Tech demo level :[g0p15t4 | "Leap With The Sky Wiggler" by Spekio @3719xx](https://lvlhd.co/+g0p15t4) (after the 3rd checkpoint)
+
+## Prize Blocks
+
+### Invisible Prizeblock Jump _(AKA Secret Keeper)_
+Just after moving up and through an upside-down invisible prize block, press jump. Gr-18 will jump again and not open the prize block.
+
+Tech demo level :[ztjjfl1 | "Prize Block?" by JewCraft42 @b9xpnn](https://lvlhd.co/+ztjjfl1)
+Tech demo video :[Levelhead - ??? Jump](https://youtu.be/baGwcrs6DBU)- Intuition
+
+## Powered Gate
+
+### Gate Jump
+If a door closes on GR-18 and he is inside of the block, but only enough to be pushed out and not crushed, he can perform another jump off of the gate itself. A full jump can be made from the top of the gate, adding **2** tiles to whichever jump you can perform off the gate.
+
+Tech Demo Level:[b7r0ws7 | "Powered Gate Flingo" by Toxin King @b2p7k7](https://lvlhd.co/+b7r0ws7)
+
+## Spikeatrons
+
+### Pixel Toe _(AKA Ledge Jumping, One-toe Ledging)_
+Using the properties of the circular hazard hitbox, it is possible to stand GR-18 on the very edge of a solid block that has a Spiketron above it. This also applies to Spike Traps and Whizblades. This does not apply to 1x scale Cromblers.
+
+Tech Demo Level :[j00xml0 | "The Tree Of Legend" by RetrophileTV @d29oze](https://lvlhd.co/+j00xml0)

--- a/source/content/tech-list/items.md
+++ b/source/content/tech-list/items.md
@@ -1,0 +1,63 @@
++++
+title = "Items"
+weight = 15
++++
+
+## Any Carryable
+
+### Item Boost _(AKA Kick Boost)_
+While in the air, throw any item downwards. This provides GR-18 with an extra tile of height. Any carryable, including those that don’t go down can be used to perform this.
+
+Tech demo video :[Levelhead Item Hopping Example](https://www.youtube.com/watch?v=MXkydn-30Yg)- TripleB36 (Opening section)
+
+### Item Hop
+Item hopping allows GR-18 to traverse a row of Spiketrons using throwable items. While holding down and a lateral direction, repeatedly press grab. GR-18 will alternate throwing the item down and picking the item up. The kick boost from throwing the item down prevents GR-18 from touching the ground. This can be done under a 2 high ceiling. This tech can be done with any carryable.
+
+Tech demo level :[3jq0l84 | "Vacsteak Hop" by tripleB36 @1nv7rl](https://lvlhd.co/+3jq0l84)
+Tech demo video :[Levelhead Item Hopping Example](https://www.youtube.com/watch?v=MXkydn-30Yg)- TripleB36
+
+## Armor Plate
+
+### Enemy Go-Through Bounce
+While equipped with either a D-Bot or an Armor Plate, jump up through an enemy. Press jump at the top of the enemy. GR-18 will jump as per a normal Kill Jump or Kill Launch.
+
+Tech demo level :[7v3961c | "Armor Plate Enemy Womp¿" by aradarbel10](https://levelhead.io/+7v3961c)
+
+Tech demo video :[LevelHead [CL] - Armor Plate Enemy Womp¿ by aradarbel10](https://www.youtube.com/watch?v=XEjU9aSQN2I)
+
+### Fortified Dash
+
+See [Waylay - Fortified Dash]({{< relref "all-powered-up.md#fortified-dash" >}})
+
+## Bomb
+
+### Bomb Jump
+Stand on an exploding bomb.GR-18 launches **12** tiles into the air.
+
+Tech demo video :[Levelhead - Glossary of Advanced Techniques](https://youtu.be/m1AH-9Dm4gk?t=43)- Flan
+
+### Extended Bomb Jump
+By standing on the same tile as exploding bomb and holding jump as the bomb explodes, GR-18 launches **22** tiles into the air. The closer to the detonation point, the higher the launch.
+
+Tech demo video :[Levelhead - Glossary of Advanced Techniques](https://youtu.be/m1AH-9Dm4gk?t=50)- Flan
+
+### Bomb Jump Momentum Cancel
+Begin holding the jump just as a the bomb goes off and release to cancel the momentum caused by the bomb. The initial press time is precise.
+
+Tech demo video :[Levelhead - Glossary of Advanced Techniques](https://youtu.be/m1AH-9Dm4gk?t=61)- Flan
+
+## D-Bot
+
+### Enemy Go-Through Bounce
+
+[See entry in Armor Plate.]({{< relref "items.md#enemy-go-trough-bounce" >}})
+
+## Throw Block
+
+### Block Jump
+
+[See entry under Package Jump]({{< relref "you-and-the-goods.md#package-jump" >}})
+
+### Up-Boosted Block Jump
+
+[See entry under Package Jump]({{< relref "you-and-the-goods.md#up-boosted-package-jump" >}})

--- a/source/content/tech-list/rip.md
+++ b/source/content/tech-list/rip.md
@@ -1,0 +1,36 @@
++++
+title = "R.I.P (Stuff that got Patched or turned into features)"
+weight = 15
++++
+
+## ^Patch 0.9.8^
+You no longer decelerate if you are pressing a direction key that is the same direction as your inherited Xspeed from a treadmill or a platform. You will only decelerate the inherited speed if you push \*against\* it.
+
+## Toe Slide Assisted Waylay Fade-away
+Jumping straight up off of a toe slider followed by an ariel charge into a wall causes the rebound momentum to stay, bouncing further back than possible.
+
+Tech demo level :[jsgn9tc | "Rough Waylay Tutorial!" by Intuition @g3204t](https://lvlhd.co/+jsgn9tc) (challenge after the 3rd checkpoint)
+
+### ^Patch 0.14.?^
+Enemies would sometimes start facing different directions depending on whether you restarted the level or were starting for the first time. This has been fixed, but will only be applied to levels published during or after this version.
+
+## Lizumi
+
+### Quirky Lizumi Restart _(AKA Lizumi quirky behaviour)_
+Lizumi usually always starts walking to the left. However, if GR-18 stands on the right side of any Lizumi and you pause the game. You'll notice that it "turns" towards GR-18. "Restart" the level now. The Lizumi that's supposed to walk to the left after "starting" the level - will now be going to the right! The same applies to reaching the Goal & restarting from there!
+
+Tech demo level :[s0kckqq | "Impossible!?!" by Intuition @g3204t](https://lvlhd.co/+s0kckqq)
+Tech demo video :[Quirky Behaviour by Intuition](https://youtu.be/1H9x4YmtG6k)
+
+## ???
+Woke up one morning and it was broken.
+
+### Zipper Squeeze-In
+Zipper’s teleport can get you into spaces you might not expect, such as between spiketrons and cromblers
+
+Tech Demo Level:[qps2ml3 | "Zipper Spiketron Box" by That Guy @34g48f](https://lvlhd.co/+qps2ml3)
+
+### Waylay Speed Jump _(AKA Coyote Charge Jump)_
+Charging and then jumping from just over the edge allows GR-18 to make a lengthy jump. (needed : jump distance/height)
+
+Tech demo level :[lvn0dcp | "Waylay Speed Jump Test" by SleepyDoof @zchv6z](https://lvlhd.co/+lvn0dcp)


### PR DESCRIPTION
The missing sections where converted from the html download of the tech list using a custom script.
I did some manual cleanup (alternative names were missing some letters, and all the links had to be cleaned up) for the errors I could find, though there might still be some. Not entirely sure if I did the local relative links correctly, I didn't know how to test it with Hugo.
I tried to be consistent with the sections that have already been added, so the GIFs and entry credit were removed.

It might be useful to do a full consistency pass over everything later, because any inconsistencies that were in the original have been converted over.